### PR TITLE
Fixed max number of cars

### DIFF
--- a/CS302 - Data Structures/PA11-PC3/rushClasses.cpp
+++ b/CS302 - Data Structures/PA11-PC3/rushClasses.cpp
@@ -55,6 +55,9 @@ Board& Board::operator=( const Board& other )
    /// if they are not the same board
    if( this != &other )
    {
+      /// clear the current board
+      clear(); 
+      
       /// set number of cars
       numCars = other.numCars;
       
@@ -243,18 +246,15 @@ bool Board::canMove( int row, int col ) const
 }
 
 /**
- * getNumCars
+ * clear
  * 
- * Returns number of cars in board.
- * 
- * @return int number of cars in board
+ * Clears all data from the board, including number of cars and
+ * data within boardCars.
 */
-int Board::getNumCars() const
+void Board::clear()
 {
-   return numCars;
+   numCars = 0;
 }
-
-
 
 
 

--- a/CS302 - Data Structures/PA11-PC3/rushClasses.h
+++ b/CS302 - Data Structures/PA11-PC3/rushClasses.h
@@ -36,7 +36,7 @@ class Board
          bool backward( int );
          bool isSolved() const;
          bool canMove( int, int ) const;
-         int getNumCars() const;
+         void clear();
          int numCars;
          Car boardCars[ 18 ];
 };

--- a/CS302 - Data Structures/PA11-PC3/rushSTL.cpp
+++ b/CS302 - Data Structures/PA11-PC3/rushSTL.cpp
@@ -17,7 +17,7 @@
 #include <sstream>
 #include <map>
 #include <queue>
-#include "rushClasses.cpp"
+#include "rushClasses.h"
 using namespace std;
 
 /// global constants
@@ -188,8 +188,7 @@ string boardToString( const Board& board )
    stringstream ss;
    string returnString;
    
-   /// concatenate string with each car's data
-   ss << board.numCars;
+   /// concatenate stringstream with each car's data
    for( i = 0; i < board.numCars; i++ )
    {
       ss << board.boardCars[i].length
@@ -197,8 +196,9 @@ string boardToString( const Board& board )
          << board.boardCars[i].orientation;
    }
    
+   /// convert from string stream to string
    returnString = ss.str();
-   
+
    /// return string with car data for board
    return returnString;
 }
@@ -215,15 +215,15 @@ Board stringToBoard( const string boardString )
 {
    /// initialize
    Board board;
-   board.numCars = boardString[ 0 ] - '0';
+   board.numCars = boardString.length() / 4;
    int i;
    
    for( i = 0; i < board.numCars; i++ )
    {
-      board.boardCars[ i ].length = boardString[ ( i * 4 ) + 1 ] - '0'; 
-      board.boardCars[ i ].row = boardString[ ( i * 4 ) + 2 ] - '0'; 
-      board.boardCars[ i ].col = boardString[ ( i * 4 ) + 3 ] - '0'; 
-      board.boardCars[ i ].orientation = boardString[ ( i * 4 ) + 4 ]; 
+      board.boardCars[ i ].length = boardString[ ( i * 4 ) ] - '0'; 
+      board.boardCars[ i ].row = boardString[ ( i * 4 ) + 1 ] - '0'; 
+      board.boardCars[ i ].col = boardString[ ( i * 4 ) + 2 ] - '0'; 
+      board.boardCars[ i ].orientation = boardString[ ( i * 4 ) + 3 ]; 
    }
    
    /// return Board with data from string


### PR DESCRIPTION
This version allows for any number of cars. This was done by replacing values in a board string so that the number of cars is read by the length of the string and not from the front of the string. It also fixes an error were boards were not being cleared when copied, fixed with creation and use of clear function.
